### PR TITLE
os.rename to avoid concurrency issue when downloading chrome binaries.

### DIFF
--- a/src/driver.py
+++ b/src/driver.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from os import environ, getenv
 from os.path import dirname, join, abspath, splitext, exists
 
-from chrome_binary import download_chrome_binary
+from chrome_binary import ensure_chrome_binaries
 
 class Browser:
     def __init__(self, browser_type: str, commit_version: int) -> None:
@@ -29,7 +29,7 @@ class Browser:
                     '--disable-gpu',
                     ]
             self.options = webdriver.chrome.options.Options()
-            download_chrome_binary(browser_dir, commit_version)
+            ensure_chrome_binaries(browser_dir, commit_version)
 
         elif browser_type == 'firefox':
             options = [
@@ -72,10 +72,10 @@ class Browser:
 
             except Exception as e:
                 continue
-        #TODO
+
+        # System crashes if fails to start browser.
         if self.browser is None:
-            return False
-        #print (f'browser {self.version} starts')
+            sys.exit(f"Browser {version} fails to start..")
         WIDTH = getenv('WIDTH')
         WIDTH = 800 if not WIDTH else int(WIDTH)
         HEIGHT = getenv('HEIGHT')

--- a/src/helper.py
+++ b/src/helper.py
@@ -12,7 +12,6 @@ from shutil import copyfile
 from collections import defaultdict
 
 from chrome_binary import build_chrome_binary
-from chrome_binary import download_chrome_binary
 from chrome_binary import get_commit_from_position
 
 from contextlib import contextmanager

--- a/src/modules.py
+++ b/src/modules.py
@@ -189,7 +189,6 @@ class Bisecter(Thread):
 
     def get_chrome(self, ver: int) -> None:
         pass
-        #self.helper.download_chrome(ver)
 
     def get_pixel_from_html(self, html_file):
         return self.ref_br.get_hash_from_html(html_file, self.saveshot)


### PR DESCRIPTION
All tests are passed in Linux, but maybe not in mac because download url in `chrome_binary.py` is different between mac and linux.