### PR TITLE
Fix concurrency in ensuring browser.

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -20,6 +20,7 @@ from PIL import Image
 from io import BytesIO
 from os import walk, listdir, getenv
 from os.path import join, dirname, abspath, exists, basename
+from chrome_binary import ChromeBinary
 
 @contextmanager
 def acquire_timeout(lock, timeout):
@@ -85,15 +86,18 @@ class IOQueue:
 
         self.start_time = time.time()
 
-    def acquire_lock(self):
-        self.__queue_lock.acquire()
-
-    def release_lock(self):
-        self.__queue_lock.release()
-
     def reset_lock(self):
         if self.__queue_lock.locked():
             self.__queue_lock.release()
+
+    def download_chrome(self, commit_version: int) -> None:
+        self.__queue_lock.acquire()
+        browser_type = 'chrome'
+        parent_dir = FileManager.get_parent_dir(__file__)
+        browser_dir = join(parent_dir, browser_type)
+        cb = ChromeBinary()
+        cb.ensure_chrome_binaries(browser_dir, commit_version)
+        self.__queue_lock.release()
 
     def build_chrome(self, commit_version: int) -> None:
         browser_type = 'chrome'

--- a/src/helper.py
+++ b/src/helper.py
@@ -85,6 +85,11 @@ class IOQueue:
 
         self.start_time = time.time()
 
+    def acquire_lock(self):
+        self.__queue_lock.acquire()
+
+    def release_lock(self):
+        self.__queue_lock.release()
 
     def reset_lock(self):
         if self.__queue_lock.locked():
@@ -184,24 +189,18 @@ class IOQueue:
     def dump_queue_as_csv(self, path):
         with acquire_timeout(self.__queue_lock, 1000) as acquired:
             if not acquired: return 
-            bug_commits = set()
-            all_commits = set(listdir(dirname(path)))
+            path = join(path, 'result.csv')
             with open(path, 'w') as csvfile:
                 header = ['base', 'target', 'ref', 'file']
                 csvfile.write(','.join(header))
                 csvfile.write('\n')
                 keys = sorted(list(self.__preqs.keys()))
                 for key in keys:
-                    bug_commits.add(key[1])
                     q = self.__preqs[key]
                     for value in sorted(list(q.queue)):
                         html_file, hashes = value
                         base, target, ref = key
                         csvfile.write(f'{base}, {target}, {ref}, {html_file}\n')
-                total = len(all_commits)
-                tp = len(bug_commits)
-                fp = total - tp
-                csvfile.write(f'TOTAL: {total}, TP: {tp}, FP: {fp}\n')
 
     def dump_queue_with_sort(self, dir_path):
         with acquire_timeout(self.__queue_lock, 1000) as acquired:

--- a/src/modules.py
+++ b/src/modules.py
@@ -41,10 +41,10 @@ class CrossVersion(Thread):
 
     def start_browsers(self, vers: Tuple[int, int, int]) -> bool:
         self.stop_browsers()
-        self.helper.acquire_lock()
+        self.helper.download_chrome(vers[0])
+        self.helper.download_chrome(vers[1])
         self.__br_list.append(Browser('chrome', vers[0]))
         self.__br_list.append(Browser('chrome', vers[1]))
-        self.helper.release_lock()
         for br in self.__br_list:
             if not br.setup_browser():
                 return False
@@ -123,9 +123,7 @@ class Oracle(Thread):
 
     def start_ref_browser(self, ver: str) -> bool:
         self.stop_ref_browser()
-        self.helper.acquire_lock()
         self.ref_br = Browser(self.ref_br_type, ver)
-        self.helper.release_lock()
         return self.ref_br.setup_browser()
 
     def stop_ref_browser(self):
@@ -182,9 +180,8 @@ class Bisecter(Thread):
 
     def start_ref_browser(self, ver: int) -> bool:
         self.stop_ref_browser()
-        self.helper.acquire_lock()
+        self.helper.download_chrome(ver)
         self.ref_br = Browser('chrome', ver)
-        self.helper.release_lock()
         return self.ref_br.setup_browser()
 
     def stop_ref_browser(self) -> None:
@@ -234,7 +231,8 @@ class Bisecter(Thread):
             if cur_mid != mid:
                 cur_mid = mid
                 self.get_chrome(cur_mid)
-                if not self.start_ref_browser(cur_mid):
+                is_good = self.start_ref_browser(cur_mid)
+                if not is_good:
                     continue
 
             ref_hash = self.get_pixel_from_html(html_file)
@@ -245,7 +243,6 @@ class Bisecter(Thread):
                 new_ref_hash = self.get_pixel_from_html(html_file)
                 if new_ref_hash != ref_hash: continue
 
-            
 
             if not ImageDiff.diff_images(hashes[0], ref_hash):
                 if mid_idx + 1 == end_idx:


### PR DESCRIPTION
While running big tests, I found there were two bugs in my code.

First, sometimes the window size is not adjusted to 800x300 because of timeout due to huge cpu usage.
To address this, I used a "for loop" to double-check window size is 800x300.  

Second, there is a concurrency issue between `get_vers()` and `pop_from_queue()` in `modules.py` so it makes bisecter incorrect. To address this, I made `pop_from_queue()` returns value and versions at once.

I also updated unit test files because `pop_from_queue()` has changed.