### PR TITLE
Support flag

### DIFF
--- a/src/crossversion_test.py
+++ b/src/crossversion_test.py
@@ -65,3 +65,21 @@ class TestCrossVersion(unittest.TestCase):
     def test_nochange_html(self):
         input_html_path, ref = cross_version_(NOCHANGE_HTML)
         self.assertEqual(ref, None)
+
+
+    def test_flag(self):
+        bf = ''
+        tf = '--enable-blink-features=LayoutNG'
+        os.environ["BASEFLAG"] = bf
+        os.environ["TARGETFLAG"] = tf
+        with tempfile.TemporaryDirectory() as outdir:
+            vm = VersionManager()
+            rev = vm.get_revision(90)
+            ioq = IOQueue([], [rev, rev], None)
+            cv = CrossVersion(ioq)
+
+            cv.start_browsers([rev, rev, None])
+            self.assertEqual(cv.br_list[0].flags, [])
+            self.assertEqual(cv.br_list[1].flags, [tf])
+
+            cv.stop_browsers()

--- a/src/driver.py
+++ b/src/driver.py
@@ -23,7 +23,7 @@ return attrs;
 """
 
 class Browser:
-    def __init__(self, browser_type: str, commit_version: int) -> None:
+    def __init__(self, browser_type: str, commit_version: int, flags: str = '') -> None:
         environ["DBUS_SESSION_BUS_ADDRESS"] = '/dev/null'
 
         self.__width = 800
@@ -33,12 +33,16 @@ class Browser:
         if browser_type not in browser_types:
             raise ValueError('[DEBUG] only chrome or firefox are allowed')
 
-
+        self.browser = None
         self.__num_of_run = 0
         self.__browser_type = browser_type
 
-        self.browser = None
         self.version = commit_version
+        self.flags = []
+
+        if flags:
+            for flag in flags.split(' '):
+                self.flags.append(flag)
 
     def setup_browser(self):
         self.__num_of_run = 0
@@ -58,6 +62,7 @@ class Browser:
                             '--disable-gpu',
                             f'--window-size={self.__width},{self.__height}',
                             ]
+                    options.extend(self.flags)
                     option = webdriver.chrome.options.Options()
                     cb = ChromeBinary()
                     cb.ensure_chrome_binaries(browser_dir, self.version)

--- a/src/modules.py
+++ b/src/modules.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 class CrossVersion(Thread):
     def __init__(self, helper: IOQueue) -> None:
         super().__init__()
-        self.__br_list = []
+        self.br_list = []
 
         self.helper = helper
         self.saveshot = False
@@ -40,30 +40,30 @@ class CrossVersion(Thread):
         self.saveshot = True
 
     def get_newer_browser(self) -> Browser:
-        return self.__br_list[-1] if self.__br_list else None
+        return self.br_list[-1] if self.br_list else None
 
     def start_browsers(self, vers: Tuple[int, int, int]) -> bool:
         self.stop_browsers()
         self.helper.download_chrome(vers[0])
         self.helper.download_chrome(vers[1])
 
-        self.__br_list.append(Browser('chrome', vers[0], self.baseflag))
-        self.__br_list.append(Browser('chrome', vers[1], self.targetflag))
-        for br in self.__br_list:
+        self.br_list.append(Browser('chrome', vers[0], self.baseflag))
+        self.br_list.append(Browser('chrome', vers[1], self.targetflag))
+        for br in self.br_list:
             if not br.setup_browser():
                 return False
         return True
 
     def stop_browsers(self) -> None:
-        for br in self.__br_list:
+        for br in self.br_list:
             br.kill_browser()
-        self.__br_list.clear()
+        self.br_list.clear()
 
     def cross_version_test_html(self, html_file: str) -> Optional[list]:
         img_hashes = []
 
         thread_id = current_thread()
-        for br in self.__br_list:
+        for br in self.br_list:
             self.helper.record_current_test(thread_id, br, html_file)
             hash_v = br.get_hash_from_html(html_file, self.saveshot)
             if hash_v is None:
@@ -647,6 +647,8 @@ class FirefoxRegression(Preprocesser):
         ])
 
         self.oracle_br = {'type': 'firefox', 'ver': oracle_version}
+        if os.getenv('BASEFLAG', '') != os.getenv('TARGETFLAG', ''):
+            self.skip_bisect()
 
     def skip_bisect(self):
         self.tester.remove(Bisecter)

--- a/src/modules.py
+++ b/src/modules.py
@@ -33,6 +33,9 @@ class CrossVersion(Thread):
         self.helper = helper
         self.saveshot = False
 
+        self.baseflag = os.getenv('BASEFLAG', '')
+        self.targetflag = os.getenv('TARGETFLAG', '')
+
     def report_mode(self) -> None:
         self.saveshot = True
 
@@ -43,8 +46,9 @@ class CrossVersion(Thread):
         self.stop_browsers()
         self.helper.download_chrome(vers[0])
         self.helper.download_chrome(vers[1])
-        self.__br_list.append(Browser('chrome', vers[0]))
-        self.__br_list.append(Browser('chrome', vers[1]))
+
+        self.__br_list.append(Browser('chrome', vers[0], self.baseflag))
+        self.__br_list.append(Browser('chrome', vers[1], self.targetflag))
         for br in self.__br_list:
             if not br.setup_browser():
                 return False
@@ -631,6 +635,7 @@ class FirefoxRegression(Preprocesser):
                  base_version: int, target_version: int, oracle_version: int) -> None:
         super().__init__(input_dir, output_dir, num_of_threads, base_version, target_version)
 
+
         self.tester.extend([
                 Oracle,
                 Bisecter,
@@ -643,6 +648,8 @@ class FirefoxRegression(Preprocesser):
 
         self.oracle_br = {'type': 'firefox', 'ver': oracle_version}
 
+    def skip_bisect(self):
+        self.tester.remove(Bisecter)
 
     def answer(self, answer_version) -> None:
         print ('answer step')

--- a/src/r2z2.py
+++ b/src/r2z2.py
@@ -2,19 +2,18 @@ import argparse
 
 from random import seed
 
-from modules import Preprocesser
 from modules import FirefoxRegression
 
 from os.path import join, dirname, basename
 
 def main():
     parser = argparse.ArgumentParser(description='Usage')
-    parser.add_argument('-i', '--input', required=False, type=str, default='', help='input directory')
+    parser.add_argument('-i', '--input', required=True, type=str, default='', help='input directory')
     parser.add_argument('-o', '--output', required=True, type=str, help='output directory')
     parser.add_argument('-j', '--job', required=False, type=int, default=1, help='number of threads')
-    parser.add_argument('-b', '--base', required=True, type=int, help='milestone')
-    parser.add_argument('-t', '--target', required=True, type=int, help='milestone')
-    parser.add_argument('-f', '--firefox', required=True, type=int, help='firefox commit')
+    parser.add_argument('-b', '--base', required=True, type=int, help='Version of base Chrome (e.g., 80)')
+    parser.add_argument('-t', '--target', required=True, type=int, help='version of target Chrome (e.g., 81)')
+    parser.add_argument('-f', '--firefox', required=True, type=str, help='firefox version')
     args = parser.parse_args()
 
     seed(0)


### PR DESCRIPTION
I updated to support flag testing. 

You can provide the base flag and target flag by setting the environment variable "BASEFLAG" and "TARGETFLAG", respectively.

Unit test:
`python3 -m unittest crossversion_test` 