### PR TITLE
Fixed concurrency bug of pop_from_queue function and edited unittest.

### DIFF
--- a/src/chrome_binary.py
+++ b/src/chrome_binary.py
@@ -82,12 +82,7 @@ class ChromeBinary:
         revision = str(revision)
         binary_dir_path = os.path.join(path, revision)
         if os.path.exists(binary_dir_path):
-            brp = self.get_browser_path(path, revision)
-            drp = self.get_driver_path(path, revision)
-            if os.path.exists(brp) and os.path.exists(drp):
-                return True
-            else:
-                shutil.rmtree(binary_dir_path)
+            return True
 
 
         # Multiple threads may call this function simultaneously. To prevent races,

--- a/src/chrome_binary.py
+++ b/src/chrome_binary.py
@@ -82,7 +82,13 @@ class ChromeBinary:
         revision = str(revision)
         binary_dir_path = os.path.join(path, revision)
         if os.path.exists(binary_dir_path):
-            return True
+            brp = self.get_browser_path(path, revision)
+            drp = self.get_driver_path(path, revision)
+            if os.path.exists(brp) and os.path.exists(drp):
+                return True
+            else:
+                shutil.rmtree(binary_dir_path)
+
 
         # Multiple threads may call this function simultaneously. To prevent races,
         # a temporary directory is used for downloading, and an atomic rename is

--- a/src/crossversion_test.py
+++ b/src/crossversion_test.py
@@ -43,7 +43,8 @@ def cross_version_(html):
 
 class TestCrossVersion(unittest.TestCase):
     def test_change_html(self):
-        input_html_path, ref = cross_version_(CHANGE_HTML)
+        input_html_path, popped = cross_version_(CHANGE_HTML)
+        ref, _ = popped
 
         html_file, hashes = ref
         self.assertEqual(html_file, input_html_path)

--- a/src/driver.py
+++ b/src/driver.py
@@ -113,7 +113,6 @@ class Browser:
                 break
             except Exception as e:
                 print (e)
-                time.sleep(0.5)
                 continue
 
         return True

--- a/src/driver.py
+++ b/src/driver.py
@@ -113,6 +113,9 @@ class Browser:
                 break
             except Exception as e:
                 print (e)
+                time.sleep(0.5)
+                continue
+
         return True
 
 

--- a/src/helper.py
+++ b/src/helper.py
@@ -144,7 +144,7 @@ class IOQueue:
                 self.__preqs.pop(vers)
                 self.__vers = self.__select_vers()
             self.num_of_tests += 1
-            return value
+            return value, vers
 
     def get_vers(self) -> Optional[Tuple[int, int, int]]:
         with acquire_timeout(self.__queue_lock, 1000) as acquired:

--- a/src/modules.py
+++ b/src/modules.py
@@ -654,15 +654,11 @@ class FirefoxRegression(Preprocesser):
         report_dict = defaultdict(list)
         bug_dict = defaultdict(int)
         nonbug_dict = defaultdict(int)
-        num = 0
         while True:
             popped = hpr.pop_from_queue()
             if not popped: break
 
             result, vers = popped
-
-            num += 1
-
             html_file, hashes = result
             if len(hashes) != 2:
                 raise ValueError('Something wrong in hashes...')
@@ -682,7 +678,6 @@ class FirefoxRegression(Preprocesser):
             else:
                 nonbug_dict[culprit] += 1
 
-        print ('Tested in answer()', num)
         ref_br.kill_browser()
         self.ioq.move_to_preqs()
         dir_path = os.path.join(self.out_dir, 'Report')

--- a/src/modules.py
+++ b/src/modules.py
@@ -90,11 +90,10 @@ class CrossVersion(Thread):
         hpr = self.helper
         while True:
 
-            vers = hpr.get_vers()
-            if not vers: break
+            popped = hpr.pop_from_queue()
+            if not popped: break
 
-            result = hpr.pop_from_queue()
-            if not result: break
+            result, vers = popped
             html_file, _ = result
 
             if cur_vers != vers:
@@ -140,11 +139,10 @@ class Oracle(Thread):
         cur_refv = None
         hpr = self.helper
         while True:
-            vers = hpr.get_vers()
-            if not vers: break
+            popped = hpr.pop_from_queue()
+            if not popped: break
 
-            result = hpr.pop_from_queue()
-            if not result: break
+            result, vers = popped
             html_file, hashes = result
             if len(hashes) != 2:
                 raise ValueError('Something wrong in hashes...')
@@ -200,13 +198,10 @@ class Bisecter(Thread):
         hpr = self.helper
 
         while True:
-            vers = hpr.get_vers()
-            if not vers:
-                break
+            popped = hpr.pop_from_queue()
+            if not popped: break
 
-            result = hpr.pop_from_queue(False)
-            if not result:
-                break
+            result, vers = popped
             html_file, hashes = result
             if len(hashes) != 2:
                 raise ValueError('Something wrong in hashes...')
@@ -231,20 +226,14 @@ class Bisecter(Thread):
             if cur_mid != mid:
                 cur_mid = mid
                 self.get_chrome(cur_mid)
-                is_good = self.start_ref_browser(cur_mid)
-                if not is_good:
+                if not self.start_ref_browser(cur_mid):
                     continue
 
             ref_hash = self.get_pixel_from_html(html_file)
             if ref_hash is None:
                 continue
 
-            for _ in range(1):
-                new_ref_hash = self.get_pixel_from_html(html_file)
-                if new_ref_hash != ref_hash: continue
-
-
-            if not ImageDiff.diff_images(hashes[0], ref_hash):
+            elif not ImageDiff.diff_images(hashes[0], ref_hash):
                 if mid_idx + 1 == end_idx:
                     hpr.update_postq((mid, end, ref), html_file, hashes)
                     #print (html_file, mid, end, 'postq 1')
@@ -494,11 +483,10 @@ class Minimizer(CrossVersion):
         cur_vers = None
         hpr = self.helper
         while True:
-            vers = hpr.get_vers()
-            if not vers: break
+            popped = hpr.pop_from_queue()
+            if not popped: break
 
-            result = hpr.pop_from_queue()
-            if not result: break
+            result, vers = popped
             html_file, _ = result
 
             if cur_vers != vers:
@@ -666,13 +654,14 @@ class FirefoxRegression(Preprocesser):
         report_dict = defaultdict(list)
         bug_dict = defaultdict(int)
         nonbug_dict = defaultdict(int)
-
+        num = 0
         while True:
-            vers = hpr.get_vers()
-            if not vers: break
+            popped = hpr.pop_from_queue()
+            if not popped: break
 
-            result = hpr.pop_from_queue()
-            if not result: break
+            result, vers = popped
+
+            num += 1
 
             html_file, hashes = result
             if len(hashes) != 2:
@@ -693,6 +682,7 @@ class FirefoxRegression(Preprocesser):
             else:
                 nonbug_dict[culprit] += 1
 
+        print ('Tested in answer()', num)
         ref_br.kill_browser()
         self.ioq.move_to_preqs()
         dir_path = os.path.join(self.out_dir, 'Report')

--- a/src/oracle_test.py
+++ b/src/oracle_test.py
@@ -51,7 +51,8 @@ def oracle_(html):
 
 class TestOracle(unittest.TestCase):
     def test_bug_html(self):
-        input_html_path, ref = oracle_(BUG_HTML)
+        input_html_path, popped = oracle_(BUG_HTML)
+        ref, _ = popped
 
         html_file, hashes = ref
         self.assertEqual(html_file, input_html_path)


### PR DESCRIPTION
There was a concurrency bug between `get_vers()` and `pop_from_queue()` and this commit fixed it.
Now the bisecter can correctly bisect the regressions.