### PR TITLE
Generate html testcases if input directory is empty

### DIFF
--- a/src/domato/generator.py
+++ b/src/domato/generator.py
@@ -477,6 +477,18 @@ def get_option(option_name):
             return sys.argv[i][len(option_name) + 1:]
     return None
 
+def generate_testcases(out_dir, index, num_of_tests):
+    fuzzer_dir = os.path.dirname(__file__)
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
+    out_dir = os.path.join(out_dir, str(index))
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
+    outfiles = []
+    for i in range(num_of_tests):
+        outfiles.append(os.path.join(out_dir, str(index) + '-' + str(i).zfill(7) + '.html'))
+    generate_samples(fuzzer_dir, outfiles)
+
 
 def main(index):
     fuzzer_dir = os.path.dirname(__file__)
@@ -508,7 +520,6 @@ def main(index):
             outfiles.append(os.path.join(out_dir, str(index) + '-' + str(i).zfill(7) + '.html'))
 
         generate_samples(fuzzer_dir, outfiles)
-        
 
     elif len(sys.argv) > 1:
         outfile = sys.argv[1]

--- a/src/preprocesser_test.py
+++ b/src/preprocesser_test.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+
+import tempfile
+
+from helper import FileManager
+from modules import Preprocesser
+
+class TestPreprocesser(unittest.TestCase):
+    def test_html_generation_if_input_dir_is_empty(self):
+        num_of_thread = 4
+        ver1 = 90
+        ver2 = 91
+        with tempfile.TemporaryDirectory() as indir:
+            with tempfile.TemporaryDirectory() as outdir:
+                Preprocesser(indir, outdir, num_of_thread, ver1, ver2)
+            self.assertTrue(len(FileManager.get_all_files(indir, '.html')), num_of_thread * 1000)


### PR DESCRIPTION
This patch will automatically generate html testcases if the input directory is empty.

You can test with `python3 -m unittest preprocesser_test`